### PR TITLE
ci: use lts/* version of NodeJS in GitHub Actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,6 +15,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+
       - name: Lint Code Base
         uses: github/super-linter@v4.9.2
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+
       - name: Install modules
         run: CYPRESS_INSTALL_BINARY=0 npm install
 


### PR DESCRIPTION
Update E2E, Linter and Test workflows.
